### PR TITLE
Use "bin" in package.json to create node_modules/.bin symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,79 +6,81 @@ A set of shell scripts to help with publishing to NPM (Helping deal with tagging
 
 1. Install module
 
-```sh
-npm install --save-dev npm-publish-scripts
-```
+  ```sh
+  npm install --save-dev npm-publish-scripts
+  ```
 
-1. Add NPM scripts for `npm-publish-scripts` to call when you publish
+2. Add NPM scripts for `npm-publish-scripts` to call when you publish:
 
-```json
-"scripts": {
-  "build": "gulp",
-  "build-docs": "jsdoc",
-  "test": "mocha",
-  "bundle": "./project/create-release-bundle.sh"
-}
-```
+  ```json
+  "scripts": {
+    "build": "gulp",
+    "build-docs": "jsdoc",
+    "test": "mocha",
+    "bundle": "./project/create-release-bundle.sh"
+  }
+  ```
+  
+  ### npm run build
+  
+  This should build your project if you need it (i.e. minification or
+  transpilation).
+  
+  ### npm run build-docs
+  
+  If you have docs this should generate call any scripts needed to generate
+  them.
+  
+  ### npm run test
+  
+  This script will run your tests before releasing, this ensures the project
+  is healthy before the release is published.
+  
+  ### npm run bundle <Path>
+  
+  When `npm run bundle` is called, it's given a directory as an argument.
+  This directory is where you should copy any and all files that you want to
+  be included in the final release. (i.e. docs, LICENSE, README, src/,
+  build/, etc). See
+  [project/create-release-bundle.sh](https://github.com/GoogleChrome/npm-publish-scripts/blob/master/project/create-release-bundle.sh)
+  to see what this project does in `bundle`.
 
-### npm run build
+1. To make this helper a little easier to use at publish time, you can add an npm script to use this.
 
-This should build your project if you need it (i.e. minification or
-transpilation).
-
-### npm run build-docs
-
-If you have docs this should generate call any scripts needed to generate
-them.
-
-### npm run test
-
-This script will run your tests before releasing, this ensures the project
-is healthy before the release is published.
-
-### npm run bundle <Path>
-
-When `npm run bundle` is called, it's given a directory as an argument.
-This directory is where you should copy any and all files that you want to
-be included in the final release. (i.e. docs, LICENSE, README, src/,
-build/, etc). See
-[project/create-release-bundle.sh](https://github.com/GoogleChrome/npm-publish-scripts/blob/master/project/create-release-bundle.sh)
-to see what this project does in `bundle`.
-
-1. To make this helper a little easier to use at publish time, you can add
-   an npm script to use this.
-
-```json
-"scripts": {
- "publish-release": "publish-release.sh"
-}
-```
-
- Then to publish just call `npm run publish-release`.
-
- **NOTE:** Do NOT call this 'release', this conflicts with an NPM reserved
- command.
+  ```json
+  "scripts": {
+    "publish-release": "publish-release.sh"
+  }
+  ```
+  
+  Then to publish just call
+  
+  ```sh
+  npm run publish-release
+  ```
+  
+  **NOTE:** Do NOT call this 'release', this conflicts with an NPM reserved command.
 
 1. Finally, permform a release:
-
-```sh
-npm run publish-release minor stable
-```
-
-The options are:
-
- - `patch` | `minor` | `major`
- 
-This outlines the type of update, patch will bump 0.0.X value.
-So for current version 0.0.1, a new patch release would be 0.0.2.
-
-Minor goes from 0.0.1 to 0.1.1.
-
-Major goes from 0.0.1 to 1.0.1
-
-- `stable` | `alpha` | `beta`
-
-This is the kind of release. Stable will publish on Github and NPM
-as a normal release. Alpha or Beta will add a tag to NPM so users
-must use `npm install project-name@alpha` or
-`npm install project-name@beta`.
+  
+  ```sh
+  npm run publish-release minor stable
+  ```
+  
+  The options are:
+  
+   - `patch` | `minor` | `major`
+   
+  This outlines the type of update, patch will bump 0.0.X value.
+  So for current version 0.0.1, a new patch release would be 0.0.2.
+  
+  Minor goes from 0.0.1 to 0.1.1.
+  
+  Major goes from 0.0.1 to 1.0.1
+  
+  - `stable` | `alpha` | `beta`
+  
+  This is the kind of release. Stable will publish on Github and NPM
+  as a normal release. Alpha or Beta will add a tag to NPM so users
+  must use `npm install project-name@alpha` or
+  `npm install project-name@beta`.

--- a/README.md
+++ b/README.md
@@ -6,71 +6,79 @@ A set of shell scripts to help with publishing to NPM (Helping deal with tagging
 
 1. Install module
 
-    npm install --save-dev npm-publish-scripts
+```sh
+npm install --save-dev npm-publish-scripts
+```
 
 1. Add NPM scripts for `npm-publish-scripts` to call when you publish
 
-    "scripts": {
-      "build": "gulp",
-      "build-docs": "jsdoc",
-      "test": "mocha",
-      "bundle": "./project/create-release-bundle.sh"
-    },
+```json
+"scripts": {
+  "build": "gulp",
+  "build-docs": "jsdoc",
+  "test": "mocha",
+  "bundle": "./project/create-release-bundle.sh"
+}
+```
 
+### npm run build
 
-    ### npm run build
+This should build your project if you need it (i.e. minification or
+transpilation).
 
-    This should build your project if you need it (i.e. minification or
-    transpilation).
+### npm run build-docs
 
-    ### npm run build-docs
+If you have docs this should generate call any scripts needed to generate
+them.
 
-    If you have docs this should generate call any scripts needed to generate
-    them.
+### npm run test
 
-    ### npm run test
+This script will run your tests before releasing, this ensures the project
+is healthy before the release is published.
 
-    This script will run your tests before releasing, this ensures the project
-    is healthy before the release is published.
+### npm run bundle <Path>
 
-    ### npm run bundle <Path>
-
-    When `npm run bundle` is called, it's given a directory as an argument.
-    This directory is where you should copy any and all files that you want to
-    be included in the final release. (i.e. docs, LICENSE, README, src/,
-    build/, etc). See
-    [project/create-release-bundle.sh](https://github.com/GoogleChrome/npm-publish-scripts/blob/master/project/create-release-bundle.sh)
-    to see what this project does in `bundle`.
+When `npm run bundle` is called, it's given a directory as an argument.
+This directory is where you should copy any and all files that you want to
+be included in the final release. (i.e. docs, LICENSE, README, src/,
+build/, etc). See
+[project/create-release-bundle.sh](https://github.com/GoogleChrome/npm-publish-scripts/blob/master/project/create-release-bundle.sh)
+to see what this project does in `bundle`.
 
 1. To make this helper a little easier to use at publish time, you can add
    an npm script to use this.
 
-   "scripts": {
-     "publish-release": "./node_modules/npm-publish-scripts/publish-release.sh"
-     ....
-   }
+```json
+"scripts": {
+ "publish-release": "publish-release.sh"
+}
+```
 
-   Then to publish just call `npm run publish-release`.
+ Then to publish just call `npm run publish-release`.
 
-   **NOTE:** Do NOT call this 'release', this conflicts with an NPM reserved
-   command.
+ **NOTE:** Do NOT call this 'release', this conflicts with an NPM reserved
+ command.
 
- 1. Finally, permform a release:
+1. Finally, permform a release:
 
-     npm run publish-release minor stable
+```sh
+npm run publish-release minor stable
+```
 
-     The options are:
+The options are:
 
-         - patch | minor | major
-            This outlines the type of update, patch will bump 0.0.X value.
-            So for current version 0.0.1, a new patch release would be 0.0.2.
+ - `patch` | `minor` | `major`
+ 
+This outlines the type of update, patch will bump 0.0.X value.
+So for current version 0.0.1, a new patch release would be 0.0.2.
 
-            Minor goes from 0.0.1 to 0.1.1.
+Minor goes from 0.0.1 to 0.1.1.
 
-            Major goes from 0.0.1 to 1.0.1
+Major goes from 0.0.1 to 1.0.1
 
-        - stable | alpha | beta
-            This is the kind of release. Stable will publish on Github and NPM
-            as a normal release. Alpha or Beta will add a tag to NPM so users
-            must use `npm install project-name@alpha` or
-            `npm install project-name@beta`.
+- `stable` | `alpha` | `beta`
+
+This is the kind of release. Stable will publish on Github and NPM
+as a normal release. Alpha or Beta will add a tag to NPM so users
+must use `npm install project-name@alpha` or
+`npm install project-name@beta`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-publish-scripts",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "A simple set of scripts to help when publishing to NPM from a Github Repo",
   "scripts": {
     "build": "echo No Build.",
@@ -21,5 +21,9 @@
   "homepage": "https://github.com/GoogleChrome/publish-scripts#readme",
   "devDependencies": {
     "semver": "^5.3.0"
+  },
+  "bin": {
+    "publish-docs.sh": "src/publish-docs.sh",
+    "publish-release.sh": "src/publish-release.sh"
   }
 }


### PR DESCRIPTION
R: @gauntface 

In addition to creating symlinks, this also cleans up the markdown in the README a bit, since it wasn't rendering as expected on GitHub.