### PR TITLE
Tweaks to the build/dev environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "http://rubygems.org"
-ruby "2.2.0"
 
 gem 'jekyll', '>=3.1.6'
 gem 'kramdown'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -52,7 +52,7 @@ gulp.task('jekyll-serve', cb => {
 gulp.task('watch', () => {
   gulp.watch(JEKYLL_THEME_PATH + '/**/*', gulp.series('dev-jekyll-theme'));
   gulp.watch(EXAMPLE_SITE_PATH + '/**/*', gulp.series('dev-example-site', 'dev-jsdoc-build'));
-})
+});
 
 gulp.task('dev', gulp.series('clean', gulp.parallel('dev-jekyll-theme', 'dev-example-site'), 'dev-jsdoc-build', 'jekyll-serve', 'watch'));
 


### PR DESCRIPTION
R: @gauntface 

Removes the Ruby 2.2.0 requirement, which stopped it from working with later versions of Ruby.

Adds a missing `;`.