### PR TITLE
Use a package.json repository field formatted for npmjs.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,7 @@
     "publish-release": "./src/publish-release.sh",
     "publish-docs": "./src/publish-docs.sh"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com:GoogleChrome/npm-publish-scripts.git"
-  },
+  "repository": "GoogleChrome/npm-publish-scripts",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/GoogleChrome/npm-publish-scripts/issues"


### PR DESCRIPTION
R: @gauntface 

https://www.npmjs.com/package/npm-publish-scripts has a broken link to the GitHub repo:

![image](https://cloud.githubusercontent.com/assets/1749548/18646806/3d3601ee-7e81-11e6-9ad4-38743ec77d3a.png)

This updates the field to use a [shorthand notation](https://docs.npmjs.com/files/package.json#repository) that displays nicely on npmjs.com.